### PR TITLE
fix: #5 Retrieve sessions by parent

### DIFF
--- a/src/main/java/org/tutortoise/service/session/SessionController.java
+++ b/src/main/java/org/tutortoise/service/session/SessionController.java
@@ -6,10 +6,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,6 +33,24 @@ public class SessionController {
         return ResponseEntity.ok(sessionService.getSessions(null, null));
     }
 
+    @Operation(summary = "Retrieves sessions by parent", description = "This API should return a list of sessions " +
+            "based on parent id. The parentId filter allows you to retrieve sessions for a specific parent, " +
+            "while the status filter allows you to retrieve sessions based on their status (e.g., open, scheduled, completed, " +
+            "cancelled, all). If no filters are provided, it will return all sessions.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successful session retrieval"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @GetMapping(path = "/parent/{parentId}", produces = "application/json")
+    public @ResponseBody ResponseEntity<List<SessionDTO>> getSessionsByParent(
+            @PathVariable @Positive(message = "parentId needs to be a positive integer only") Integer parentId,
+            @RequestParam(required = false) String status) {
+        if (parentId == null) {
+            throw new IllegalArgumentException("Parent id cannot be null or blank");
+        }
+        return ResponseEntity.ok(sessionService.getSessionsByParent(parentId, status));
+    }
+
     @Operation(summary = "Retrieves sessions by filters", description = "This API should return a list of sessions " +
             "based on the provided filters. The tutorId filter allows you to retrieve sessions for a specific tutor, " +
             "while the status filter allows you to retrieve sessions based on their status (e.g., scheduled, completed, " +
@@ -49,7 +63,7 @@ public class SessionController {
     public @ResponseBody ResponseEntity<List<SessionDTO>> getSessions(
             @PathVariable @NotBlank @Positive(message = "tutorId needs to be a positive integer only") String tutorId,
             @RequestParam String status) {
-        if( StringUtils.isBlank(tutorId) ){
+        if (StringUtils.isBlank(tutorId)) {
             throw new IllegalArgumentException("Tutor id cannot be null or blank");
         }
         return ResponseEntity.ok(sessionService.getSessions(tutorId, status));

--- a/src/main/java/org/tutortoise/service/session/SessionRepository.java
+++ b/src/main/java/org/tutortoise/service/session/SessionRepository.java
@@ -40,7 +40,6 @@ public interface SessionRepository extends JpaRepository<Session, Integer> {
     );
 
 
-
     Page<Session> findBySessionStatusAndDatetimeStartedBetween(
             SessionStatus status,
             LocalDateTime start,
@@ -74,4 +73,8 @@ public interface SessionRepository extends JpaRepository<Session, Integer> {
             LocalDateTime endDateTime);
 
     List<Session> findByParentParentId(Integer parentId);
+
+    List<Session> findByParentParentIdAndSessionStatusAndDatetimeStartedAfterOrderByDatetimeStartedAsc(Integer parentId, SessionStatus sessionStatus, LocalDateTime now);
+
+    List<Session> findByParentParentIdAndSessionStatusAndDatetimeStartedBeforeOrderByDatetimeStartedDesc(Integer parentId, SessionStatus sessionStatus, LocalDateTime now);
 }

--- a/src/main/java/org/tutortoise/service/session/SessionRepository.java
+++ b/src/main/java/org/tutortoise/service/session/SessionRepository.java
@@ -56,4 +56,6 @@ public interface SessionRepository extends JpaRepository<Session, Integer> {
     List<Session> findByDatetimeStartedBetween(
             LocalDateTime startDateTime,
             LocalDateTime endDateTime);
+
+    List<Session> findByParentParentId(Integer parentId);
 }

--- a/src/main/java/org/tutortoise/service/session/SessionService.java
+++ b/src/main/java/org/tutortoise/service/session/SessionService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.tutortoise.service.parent.Parent;
-import org.tutortoise.service.parent.ParentRepository;
 import org.tutortoise.service.student.Student;
 import org.tutortoise.service.student.StudentDTO;
 import org.tutortoise.service.student.StudentRepository;
@@ -16,7 +15,6 @@ import org.tutortoise.service.subject.SubjectDTO;
 
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
 //import static jdk.internal.classfile.Classfile.build;
 
@@ -220,22 +218,39 @@ public class SessionService {
         List<Session> sessions =
                 sessionRepository.findByDatetimeStartedBetween(startDateTime, endDateTime);
 
-       return sessions.stream()
+        return sessions.stream()
                 .map(SessionDTO::convertToDTO)
                 .toList();
 
     }
 
-    public List<SessionDTO> getSessionsByParent(final Integer parentId,final String status) {
-        List<Session> sessions = sessionRepository.findByParentParentId(parentId);
+    public List<SessionDTO> getSessionsByParent(final Integer parentId, final String status) {
 
-        if(CollectionUtils.isEmpty(sessions)) {
+        List<Session> sessions;
+
+
+
+        if (StringUtils.isBlank(status)) {
+            sessions = sessionRepository.findByParentParentId(parentId);
+        } else {
+            if( Strings.CI.equals(status, SessionStatus.scheduled.name()) ) {
+                sessions = sessionRepository.findByParentParentIdAndSessionStatusAndDatetimeStartedAfterOrderByDatetimeStartedAsc(
+                        parentId, SessionStatus.valueOf(status), LocalDateTime.now()
+                );
+            }else{
+                sessions = sessionRepository.findByParentParentIdAndSessionStatusAndDatetimeStartedBeforeOrderByDatetimeStartedDesc(
+                        parentId, SessionStatus.valueOf(status), LocalDateTime.now()
+                );
+            }
+
+        }
+
+        if (CollectionUtils.isEmpty(sessions)) {
             return Collections.emptyList();
         }
 
         List<SessionDTO> sessionDTOS = sessions.stream()
                 .filter(Objects::nonNull)
-                .filter(s -> StringUtils.isBlank(status) || s.getSessionStatus().name().equalsIgnoreCase(status))
                 .map(SessionDTO::convertToDTO)
                 .toList();
 

--- a/src/main/java/org/tutortoise/service/session/SessionService.java
+++ b/src/main/java/org/tutortoise/service/session/SessionService.java
@@ -1,9 +1,8 @@
 package org.tutortoise.service.session;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,26 +15,17 @@ import org.tutortoise.service.student.StudentRepository;
 import org.tutortoise.service.subject.SubjectDTO;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 //import static jdk.internal.classfile.Classfile.build;
 
 @Service
+@RequiredArgsConstructor
 public class SessionService {
 
     private final SessionRepository sessionRepository;
-    private final ParentRepository parentRepository;
     private final StudentRepository studentRepository;
-
-    public SessionService(SessionRepository sessionRepository, ParentRepository parentRepository, StudentRepository studentRepository) {
-        this.sessionRepository = sessionRepository;
-        this.parentRepository = parentRepository;
-        this.studentRepository = studentRepository;
-
-    }
 
     public List<SessionDTO> getSessions(String tutorId, String status) {
         List<Session> sessions;
@@ -233,5 +223,21 @@ public class SessionService {
                 .map(SessionDTO::convertToDTO)
                 .toList();
 
+    }
+
+    public List<SessionDTO> getSessionsByParent(final Integer parentId,final String status) {
+        List<Session> sessions = sessionRepository.findByParentParentId(parentId);
+
+        if(CollectionUtils.isEmpty(sessions)) {
+            return Collections.emptyList();
+        }
+
+        List<SessionDTO> sessionDTOS = sessions.stream()
+                .filter(Objects::nonNull)
+                .filter(s -> StringUtils.isBlank(status) || s.getSessionStatus().name().equalsIgnoreCase(status))
+                .map(SessionDTO::convertToDTO)
+                .toList();
+
+        return sessionDTOS;
     }
 }


### PR DESCRIPTION
1) {host}/api/sessions/parent/{parentId} - This api in sessions controller will filter sessions by parent id.
2) Session status request parameter is optional and if you want to filter by session status, add request parameter "status"
3) Sorting of sessions depending on session status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new API endpoint allowing parents to view and filter their sessions by status.

* **Documentation**
  * Added API documentation for the new parent session retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->