### PR TITLE
fix: #5 Added sorting for tutor

### DIFF
--- a/src/main/java/org/tutortoise/service/session/SessionRepository.java
+++ b/src/main/java/org/tutortoise/service/session/SessionRepository.java
@@ -1,7 +1,5 @@
 package org.tutortoise.service.session;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -39,15 +37,6 @@ public interface SessionRepository extends JpaRepository<Session, Integer> {
             LocalDateTime end
     );
 
-
-
-    Page<Session> findBySessionStatusAndDatetimeStartedBetween(
-            SessionStatus status,
-            LocalDateTime start,
-            LocalDateTime end,
-            Pageable pageable
-    );
-
     @Query(
             value =
                     "SELECT * FROM session WHERE student_id_fk is NULL AND session_status = 'open' AND datetime_started > CURRENT_TIMESTAMP ORDER BY datetime_started ASC",
@@ -72,4 +61,13 @@ public interface SessionRepository extends JpaRepository<Session, Integer> {
     List<Session> findByDatetimeStartedBetween(
             LocalDateTime startDateTime,
             LocalDateTime endDateTime);
+
+    List<Session> findByTutorTutorIdAndSessionStatusOrderByDatetimeStartedAsc(
+            Integer tutorId, SessionStatus sessionStatus
+    );
+
+    List<Session> findByTutorTutorIdAndSessionStatusOrderByDatetimeStartedDesc(
+            Integer tutorId,
+            SessionStatus sessionStatus
+    );
 }

--- a/src/main/java/org/tutortoise/service/session/SessionRepository.java
+++ b/src/main/java/org/tutortoise/service/session/SessionRepository.java
@@ -78,8 +78,8 @@ public interface SessionRepository extends JpaRepository<Session, Integer> {
 
     List<Session> findByParentParentIdAndSessionStatusAndDatetimeStartedBeforeOrderByDatetimeStartedDesc(Integer parentId, SessionStatus sessionStatus, LocalDateTime now);
 
-    List<Session> findByTutorTutorIdAndSessionStatusOrderByDatetimeStartedAsc(
-            Integer tutorId, SessionStatus sessionStatus
+    List<Session> findByTutorTutorIdAndSessionStatusAndDatetimeStartedAfterOrderByDatetimeStartedAsc(
+            Integer tutorId, SessionStatus sessionStatus, LocalDateTime now
     );
 
     List<Session> findByTutorTutorIdAndSessionStatusOrderByDatetimeStartedDesc(

--- a/src/main/java/org/tutortoise/service/session/SessionService.java
+++ b/src/main/java/org/tutortoise/service/session/SessionService.java
@@ -16,10 +16,7 @@ import org.tutortoise.service.student.StudentRepository;
 import org.tutortoise.service.subject.SubjectDTO;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 //import static jdk.internal.classfile.Classfile.build;
 
@@ -45,12 +42,32 @@ public class SessionService {
                 || Strings.CI.equals(status, SessionStatus.all.toString())) {
             sessions = sessionRepository.findByTutorTutorId(Integer.parseInt(tutorId));
         } else {
-            sessions =
-                    sessionRepository.findByTutorTutorIdAndSessionStatus(
-                            Integer.parseInt(tutorId), SessionStatus.session(status.toLowerCase()));
+            if( Strings.CI.equals(status, SessionStatus.scheduled.name()) ) {
+
+                sessions = sessionRepository.findByTutorTutorIdAndSessionStatusOrderByDatetimeStartedAsc(
+                        Integer.parseInt(tutorId),
+                        SessionStatus.valueOf(status.toLowerCase())
+                );
+
+            } else if ( Strings.CI.equals(status, SessionStatus.completed.name()) ){
+                sessions = sessionRepository.findByTutorTutorIdAndSessionStatusOrderByDatetimeStartedDesc(
+                        Integer.parseInt(tutorId),
+                        SessionStatus.valueOf(status.toLowerCase())
+                );
+            } else{
+                sessions =
+                        sessionRepository.findByTutorTutorIdAndSessionStatus(
+                                Integer.parseInt(tutorId), SessionStatus.session(status.toLowerCase()));
+            }
         }
 
-        return sessions.stream().map(SessionDTO::convertToDTO).toList();
+        if( CollectionUtils.isEmpty(sessions) ){
+            return Collections.emptyList();
+        }
+
+        return sessions.stream()
+                .filter(Objects::nonNull)
+                .map(SessionDTO::convertToDTO).toList();
     }
 
     public List<SessionStudentData> findStudentInfoByParent(Integer parentId) {

--- a/src/main/java/org/tutortoise/service/session/SessionService.java
+++ b/src/main/java/org/tutortoise/service/session/SessionService.java
@@ -35,9 +35,10 @@ public class SessionService {
         } else {
             if( Strings.CI.equals(status, SessionStatus.scheduled.name()) ) {
 
-                sessions = sessionRepository.findByTutorTutorIdAndSessionStatusOrderByDatetimeStartedAsc(
+                sessions = sessionRepository.findByTutorTutorIdAndSessionStatusAndDatetimeStartedAfterOrderByDatetimeStartedAsc(
                         Integer.parseInt(tutorId),
-                        SessionStatus.valueOf(status.toLowerCase())
+                        SessionStatus.valueOf(status.toLowerCase()),
+                        LocalDateTime.now()
                 );
 
             } else if ( Strings.CI.equals(status, SessionStatus.completed.name()) ){


### PR DESCRIPTION
Added sorting order for tutor api in session controller. No change to any api signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Session retrieval now orders results by start time differently depending on status (ascending for scheduled sessions, descending for completed sessions).
  * Retrieval logic split to use status-specific queries for more accurate ordering.

* **Bug Fixes**
  * Empty result sets now return an empty list; null entries are filtered so callers receive consistent, non-null DTOs.
* **Chore**
  * No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->